### PR TITLE
⚡️ Copy `node_modules` directly in the image

### DIFF
--- a/.github/workflows/onPushMainPrMain.yaml
+++ b/.github/workflows/onPushMainPrMain.yaml
@@ -102,6 +102,15 @@ jobs:
       - name: 📥 Checkout repository
         uses: actions/checkout@v3
 
+      - name: 🗂 Cache "node_modules"
+        uses: actions/cache@v3
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: "**/node_modules"
+          key: ${{ runner.arch }}-${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.arch }}-${{ runner.os }}-yarn-
+
       - name: 📥 Download build artifact
         uses: actions/download-artifact@v3
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ WORKDIR /app
 COPY package.json .
 COPY yarn.lock .
 
+# Copy cached node_modules
+COPY node_modules .
+
 RUN yarn install --frozen-lockfile
 
 # Bundle built app source


### PR DESCRIPTION
To avoid download each time all dependencies