### PR TITLE
🐛 Change saving dates methods to get free games

### DIFF
--- a/src/helpers/epic.games.mapper.ts
+++ b/src/helpers/epic.games.mapper.ts
@@ -11,12 +11,12 @@ export class EpicGamesMapper {
                     description: game.description,
                     urlSlug: `https://store.epicgames.com/fr/p/${game.catalogNs.mappings[0]?.pageSlug}`,
                     promotion: {
-                        startDate: game.promotions?.promotionalOffers.length
+                        startDate: game.free 
                             ? game.promotions.promotionalOffers[0].promotionalOffers[0].startDate.toString()
                             : game.promotions?.upcomingPromotionalOffers[0]?.promotionalOffers[0].startDate.toString(),
-                        endDate: game.promotions?.promotionalOffers.length
+                        endDate: game.free 
                             ? game.promotions.promotionalOffers[0].promotionalOffers[0].endDate.toString()
-                            : game.promotions?.upcomingPromotionalOffers[0]?.promotionalOffers[0].endDate.toString(),
+                            : game.promotions?.upcomingPromotionalOffers[0]?.promotionalOffers[0].endDate.toString()
                     },
                     imageUrl: game.keyImages[1].url,
                 };

--- a/src/helpers/epic.games.mapper.ts
+++ b/src/helpers/epic.games.mapper.ts
@@ -1,12 +1,12 @@
 import { logger } from "../config/logger.config";
-import { GameCacheDocumentInterface } from "../interfaces/cache.interface";
+import { GameInterface } from "../interfaces/game.interface";
 import { Element } from "../interfaces/client.interface";
 
 export class EpicGamesMapper {
-    static map(data: Element[]): GameCacheDocumentInterface[] {
+    static map(data: Element[]): GameInterface[] {
         try {
-            const newElementsToSave: GameCacheDocumentInterface[] = data.map((game) => {
-                const newElement: GameCacheDocumentInterface = {
+            const newElementsToSave: GameInterface[] = data.map((game) => {
+                const newElement: GameInterface = {
                     title: game.title,
                     description: game.description,
                     urlSlug: `https://store.epicgames.com/fr/p/${game.catalogNs.mappings[0]?.pageSlug}`,

--- a/src/interfaces/client.interface.ts
+++ b/src/interfaces/client.interface.ts
@@ -148,6 +148,7 @@ export interface Element {
     offerMappings: OfferMapping[];
     price: Price;
     promotions: Promotions;
+    free?: boolean;
 }
 
 interface Paging {

--- a/src/interfaces/data.interface.ts
+++ b/src/interfaces/data.interface.ts
@@ -1,6 +1,6 @@
-import { GameCacheDocumentInterface } from "./cache.interface";
+import { GameInterface } from "./game.interface";
 
 export interface DatasToCompileInterface {
-    availableGames: GameCacheDocumentInterface[];
-    nextGames: GameCacheDocumentInterface[];
+    availableGames: GameInterface[];
+    nextGames: GameInterface[];
 }

--- a/src/interfaces/game.interface.ts
+++ b/src/interfaces/game.interface.ts
@@ -1,4 +1,4 @@
-export interface GameCacheDocumentInterface {
+export interface GameInterface {
     title: string;
     description: string;
     imageUrl: string;

--- a/src/services/data.service.ts
+++ b/src/services/data.service.ts
@@ -1,6 +1,6 @@
 import { DriveOutput } from "../outputs/google/drive.output";
 
-import { GameCacheDocumentInterface } from "../interfaces/cache.interface";
+import { GameInterface } from "../interfaces/game.interface";
 import { ReceiverInterface } from "../interfaces/receiver.interface";
 
 import { logger } from "../config/logger.config";
@@ -25,9 +25,9 @@ export class DataService {
         this.drive = DriveOutput.getInstance();
     }
 
-    public async getCache(): Promise<GameCacheDocumentInterface[] | null> {
+    public async getCache(): Promise<GameInterface[] | null> {
         try {
-            const cache: GameCacheDocumentInterface[] = await Object(this.drive.getDocument(this.file.cache.name));
+            const cache: GameInterface[] = await Object(this.drive.getDocument(this.file.cache.name));
             return cache;
         } catch (error) {
             logger.error(error);
@@ -35,7 +35,7 @@ export class DataService {
         }
     }
 
-    public async updateCache(content: GameCacheDocumentInterface[]): Promise<boolean> {
+    public async updateCache(content: GameInterface[]): Promise<boolean> {
         try {
             await this.drive.updateDocument(this.file.cache.name, JSON.stringify(content, null, 4));
             return true;

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -2,21 +2,21 @@ import fs from "fs";
 import handlebars from "handlebars";
 import packageJson from "../../package.json";
 import { logger } from "../config/logger.config";
-import { GameCacheDocumentInterface } from "../interfaces/cache.interface";
+import { GameInterface } from "../interfaces/game.interface";
 import { EmailConfigInterface, EmailOptionsInterface, EmailResponseInterface } from "../interfaces/email.interface";
 import { ReceiverInterface } from "../interfaces/receiver.interface";
 import { EmailerOutput } from "../outputs/emailer/emailer.output";
 
 interface DatasToCompileInterface {
     uuid: string | undefined;
-    availableGames: GameCacheDocumentInterface[];
-    nextGames: GameCacheDocumentInterface[];
+    availableGames: GameInterface[];
+    nextGames: GameInterface[];
 }
 
 export class EmailService {
     private emailer: EmailerOutput;
     private config: EmailConfigInterface;
-    private datas: GameCacheDocumentInterface[] = [];
+    private datas: GameInterface[] = [];
 
     constructor() {
         this.config = {
@@ -44,7 +44,7 @@ export class EmailService {
     public async sendEmails(
         subject: string,
         receivers: ReceiverInterface[],
-        datas: GameCacheDocumentInterface[]
+        datas: GameInterface[]
     ): Promise<void> {
         try {
             this.datas = datas;

--- a/src/services/game.service.ts
+++ b/src/services/game.service.ts
@@ -27,31 +27,42 @@ export class GameService {
     }
 
     private filterElements(data: Element[]): Element[] {
-        return data.filter((filteredGame) => this.isFreeGame(filteredGame));
+        return data.filter((filteredGame) => {
+            const freeNowOrAfter = this.isFreeGame(filteredGame);
+            if (freeNowOrAfter === "now") {
+                filteredGame["free"] = true;
+                return true;
+            } else if (freeNowOrAfter === "after") {
+                filteredGame["free"] = false;
+                return true;
+            }
+        });
     }
 
     /**
      * For each received game, check if it is free or not, by checking if the `discountPercentage` is equal to 0.
      *
      * @param filteredGame The game to check if it's free.
-     * @returns true if the game is free, false if not.
+     * @returns "now" for free game now, "after" for free game next week, "none" if not free
      */
-    private isFreeGame(filteredGame: Element): boolean {
-        // If the game is currently free, then return true.
+    private isFreeGame(filteredGame: Element): string {
+        let freeNowOrAfter = "none";
+
         const isCurrentlyFree =
             filteredGame.promotions?.promotionalOffers[0]?.promotionalOffers[0]?.discountSetting?.discountPercentage ===
             0;
 
-        // If the game isn't free, with a boolean to false, then check if it'll be free in the future.
-        // If is, return true, if not, return false.
-        if (!isCurrentlyFree) {
-            return (
-                filteredGame.promotions?.upcomingPromotionalOffers[0]?.promotionalOffers[0]?.discountSetting
-                    ?.discountPercentage === 0
-            );
+        // The game is free now ? return "now"
+        if (isCurrentlyFree) {
+            return freeNowOrAfter = "now";
+        } 
+        const isAfterFree = filteredGame.promotions?.upcomingPromotionalOffers[0]?.promotionalOffers[0]?.discountSetting
+            ?.discountPercentage === 0;
+        // The game is free after ? return "after"
+        if (isAfterFree) {
+            return freeNowOrAfter = "after";
         }
-
-        // If the game is free, return true. In any case.
-        return isCurrentlyFree;
+        // If no condition is filled, return "none"
+        return freeNowOrAfter;
     }
 }

--- a/test/data/games.json
+++ b/test/data/games.json
@@ -1251,5 +1251,1114 @@
             "lineOffers": [{ "appliedRules": [] }]
         },
         "promotions": null
+    },
+    {
+        "title": "Mocked game 13",
+        "id": "aec117239abd49a08eddc9e75a981fa3",
+        "namespace": "2f215955790d456b80c291bc2feaf7f7",
+        "description": "Shadow Tactics est un jeu tactique intense d'infiltration dont l'histoire se déroule au Japon, au cours de la période d'Edo. Un nouveau shogun a pris le pouvoir au Japon et impose la paix à la nation entière. Il engage cinq spécialistes aux talents exceptionnels en assassinat ...",
+        "effectiveDate": "2019-12-28T16:00:00.000Z",
+        "offerType": "BASE_GAME",
+        "expiryDate": null,
+        "status": "ACTIVE",
+        "isCodeRedemptionOnly": false,
+        "keyImages": [
+            {
+                "type": "DieselStoreFrontWide",
+                "url": "https://cdn1.epicgames.com/undefined/offer/EGS_MimimiGames_ShadowTacticsBladesoftheShogun_S3-1360x766-216c2e04b177c6b7252f1f535edef030.jpg"
+            },
+            {
+                "type": "DieselStoreFrontTall",
+                "url": "https://cdn1.epicgames.com/undefined/offer/EGS_MimimiGames_ShadowTacticsBladesoftheShogun_S4-510x680-f62935abb1b2bd42b2f19f9385da7fe7.jpg"
+            },
+            {
+                "type": "OfferImageTall",
+                "url": "https://cdn1.epicgames.com/undefined/offer/EGS_MimimiGames_ShadowTacticsBladesoftheShogun_S4-510x680-f62935abb1b2bd42b2f19f9385da7fe7.jpg"
+            },
+            {
+                "type": "Thumbnail",
+                "url": "https://cdn1.epicgames.com/2f215955790d456b80c291bc2feaf7f7/offer/EGS_MimimiGames_ShadowTacticsBladesoftheShogun_S4-510x680-f62935abb1b2bd42b2f19f9385da7fe7.jpg"
+            },
+            {
+                "type": "CodeRedemption_340x440",
+                "url": "https://cdn1.epicgames.com/2f215955790d456b80c291bc2feaf7f7/offer/EGS_MimimiGames_ShadowTacticsBladesoftheShogun_S4-510x680-f62935abb1b2bd42b2f19f9385da7fe7.jpg"
+            },
+            {
+                "type": "OfferImageWide",
+                "url": "https://cdn1.epicgames.com/undefined/offer/EGS_MimimiGames_ShadowTacticsBladesoftheShogun_S3-1360x766-216c2e04b177c6b7252f1f535edef030.jpg"
+            }
+        ],
+        "seller": { "id": "o-d2ygr9bjcjfebgt8842wvvbmswympz", "name": "Daedalic Entertainment" },
+        "productSlug": "shadow-tactics/home",
+        "urlSlug": "fangtoothgeneralaudience",
+        "url": null,
+        "items": [{ "id": "889ac01c253348cab7f3ac9186998b6a", "namespace": "2f215955790d456b80c291bc2feaf7f7" }],
+        "customAttributes": [
+            { "key": "com.epicgames.app.blacklist", "value": "[]" },
+            { "key": "publisherName", "value": "Daedalic Entertainment" },
+            { "key": "developerName", "value": "Mimimi Games" },
+            { "key": "com.epicgames.app.productSlug", "value": "shadow-tactics/home" }
+        ],
+        "categories": [
+            { "path": "freegames" },
+            { "path": "games" },
+            { "path": "games/edition/base" },
+            { "path": "games/edition" },
+            { "path": "applications" }
+        ],
+        "tags": [
+            { "id": "14944" },
+            { "id": "21122" },
+            { "id": "1188" },
+            { "id": "14346" },
+            { "id": "19242" },
+            { "id": "9547" },
+            { "id": "16011" },
+            { "id": "15375" },
+            { "id": "21138" },
+            { "id": "16979" },
+            { "id": "21140" },
+            { "id": "17493" },
+            { "id": "21141" },
+            { "id": "18777" },
+            { "id": "1370" },
+            { "id": "18778" },
+            { "id": "22810" },
+            { "id": "1115" },
+            { "id": "1084" },
+            { "id": "21149" },
+            { "id": "21119" }
+        ],
+        "catalogNs": { "mappings": [{ "pageSlug": "shadow-tactics", "pageType": "productHome" }] },
+        "offerMappings": [],
+        "price": {
+            "totalPrice": {
+                "discountPrice": 0,
+                "originalPrice": 3999,
+                "voucherDiscount": 0,
+                "discount": 3999,
+                "currencyCode": "EUR",
+                "currencyInfo": { "decimals": 2 },
+                "fmtPrice": { "originalPrice": "39,99 €", "discountPrice": "0", "intermediatePrice": "0" }
+            },
+            "lineOffers": [
+                {
+                    "appliedRules": [
+                        {
+                            "id": "82c325412f5d4d8b963a596ebf97e9d4",
+                            "endDate": "2022-11-17T16:00:00.000Z",
+                            "discountSetting": { "discountType": "PERCENTAGE" }
+                        }
+                    ]
+                }
+            ]
+        },
+        "promotions": {
+            "promotionalOffers": [
+                {
+                    "promotionalOffers": [
+                        {
+                            "startDate": "2022-11-10T16:00:00.000Z",
+                            "endDate": "2022-11-17T16:00:00.000Z",
+                            "discountSetting": { "discountType": "PERCENTAGE", "discountPercentage": 0 }
+                        }
+                    ]
+                }
+            ],
+            "upcomingPromotionalOffers": []
+        }
+    },
+    {
+        "title": "Mocked game 14",
+        "id": "a9748abde1c94b66aae5250bb9fc5503",
+        "namespace": "7e508f543b05465abe3a935960eb70ac",
+        "description": "Idle Champions est un jeu de gestion de stratégie licencié de Dungeons & Dragons, combinant des personnages iconiques de romans, de campagnes et d'émissions dans une aventure épique.",
+        "effectiveDate": "2021-02-16T17:00:00.000Z",
+        "offerType": "BASE_GAME",
+        "expiryDate": null,
+        "status": "ACTIVE",
+        "isCodeRedemptionOnly": false,
+        "keyImages": [
+            {
+                "type": "OfferImageTall",
+                "url": "https://cdn1.epicgames.com/offer/7e508f543b05465abe3a935960eb70ac/EpicPortrait_1200x1600_SeasonsFR_1200x1600-22fb6c40af61e6c8f1daf085ce60fbe6"
+            },
+            {
+                "type": "OfferImageWide",
+                "url": "https://cdn1.epicgames.com/offer/7e508f543b05465abe3a935960eb70ac/EpicCapsule_2560x1440_SeasonsFR_1920x1080-967b4ea07f9070d6c07809a91f3c7fb1"
+            },
+            {
+                "type": "Thumbnail",
+                "url": "https://cdn1.epicgames.com/offer/7e508f543b05465abe3a935960eb70ac/EpicPortrait_1200x1600_SeasonsFR_1200x1600-22fb6c40af61e6c8f1daf085ce60fbe6"
+            },
+            {
+                "type": "DieselStoreFrontTall",
+                "url": "https://cdn1.epicgames.com/offer/7e508f543b05465abe3a935960eb70ac/EpicPortrait_1200x1600_SeasonsFR_1200x1600-22fb6c40af61e6c8f1daf085ce60fbe6"
+            },
+            {
+                "type": "DieselStoreFrontWide",
+                "url": "https://cdn1.epicgames.com/offer/7e508f543b05465abe3a935960eb70ac/EpicCapsule_2560x1440_SeasonsFR_1920x1080-967b4ea07f9070d6c07809a91f3c7fb1"
+            }
+        ],
+        "seller": { "id": "o-3kpjwtwqwfl2p9wdwvpad7yqz4kt6c", "name": "Codename Entertainment" },
+        "productSlug": "idle-champions-of-the-forgotten-realms",
+        "urlSlug": "banegeneralaudience",
+        "url": null,
+        "items": [{ "id": "9a4e1a1eb6b140f6a9e5e4dcb5a2bf55", "namespace": "7e508f543b05465abe3a935960eb70ac" }],
+        "customAttributes": [
+            { "key": "com.epicgames.app.blacklist", "value": "KR" },
+            { "key": "publisherName", "value": "Codename Entertainment" },
+            { "key": "developerName", "value": "Codename Entertainment" },
+            { "key": "com.epicgames.app.productSlug", "value": "idle-champions-of-the-forgotten-realms" }
+        ],
+        "categories": [
+            { "path": "freegames" },
+            { "path": "games" },
+            { "path": "games/edition" },
+            { "path": "games/edition/base" },
+            { "path": "applications" }
+        ],
+        "tags": [
+            { "id": "21136" },
+            { "id": "21122" },
+            { "id": "21138" },
+            { "id": "21139" },
+            { "id": "1188" },
+            { "id": "1141" },
+            { "id": "1370" },
+            { "id": "1115" },
+            { "id": "9547" },
+            { "id": "21149" },
+            { "id": "21119" }
+        ],
+        "catalogNs": {
+            "mappings": [{ "pageSlug": "idle-champions-of-the-forgotten-realms", "pageType": "productHome" }]
+        },
+        "offerMappings": [],
+        "price": {
+            "totalPrice": {
+                "discountPrice": 0,
+                "originalPrice": 0,
+                "voucherDiscount": 0,
+                "discount": 0,
+                "currencyCode": "EUR",
+                "currencyInfo": { "decimals": 2 },
+                "fmtPrice": { "originalPrice": "0", "discountPrice": "0", "intermediatePrice": "0" }
+            },
+            "lineOffers": [{ "appliedRules": [] }]
+        },
+        "promotions": { "promotionalOffers": [], "upcomingPromotionalOffers": [] }
+    },
+    {
+        "title": "Mocked game 15",
+        "id": "141eee80fbe041d48e16e7b998829295",
+        "namespace": "4d8b727a49144090b103f6b6ba471e71",
+        "description": "La vinification pourrait être votre plus grande aventure. Produisez le meilleur vin en interagissant avec le sol et la nature et élevez votre vignoble jusqu'au sommet. Votre beau voyage dans la tradition viticole commence maintenant.",
+        "effectiveDate": "2021-05-13T14:00:00.000Z",
+        "offerType": "BASE_GAME",
+        "expiryDate": null,
+        "status": "ACTIVE",
+        "isCodeRedemptionOnly": false,
+        "keyImages": [
+            {
+                "type": "OfferImageWide",
+                "url": "https://cdn1.epicgames.com/4d8b727a49144090b103f6b6ba471e71/offer/EGS_HundredDaysWinemakingSimulatorDEMO_BrokenArmsGames_Demo_G1C_00-1920x1080-0ffeb0645f0badb615627b481b4a913e.jpg"
+            },
+            {
+                "type": "OfferImageTall",
+                "url": "https://cdn1.epicgames.com/4d8b727a49144090b103f6b6ba471e71/offer/EGS_HundredDaysWinemakingSimulatorDEMO_BrokenArmsGames_Demo_S2-1200x1600-35531ec1fa868e3876fac76471a24017.jpg"
+            },
+            {
+                "type": "Thumbnail",
+                "url": "https://cdn1.epicgames.com/4d8b727a49144090b103f6b6ba471e71/offer/EGS_HundredDaysWinemakingSimulatorDEMO_BrokenArmsGames_Demo_S2-1200x1600-35531ec1fa868e3876fac76471a24017.jpg"
+            },
+            {
+                "type": "CodeRedemption_340x440",
+                "url": "https://cdn1.epicgames.com/4d8b727a49144090b103f6b6ba471e71/offer/EGS_HundredDaysWinemakingSimulatorDEMO_BrokenArmsGames_Demo_S2-1200x1600-35531ec1fa868e3876fac76471a24017.jpg"
+            },
+            {
+                "type": "DieselStoreFrontWide",
+                "url": "https://cdn1.epicgames.com/4d8b727a49144090b103f6b6ba471e71/offer/EGS_HundredDaysWinemakingSimulatorDEMO_BrokenArmsGames_Demo_S1-2560x1440-8f0dd95b6027cd1243361d430b3bf552.jpg"
+            },
+            {
+                "type": "DieselStoreFrontTall",
+                "url": "https://cdn1.epicgames.com/4d8b727a49144090b103f6b6ba471e71/offer/EGS_HundredDaysWinemakingSimulatorDEMO_BrokenArmsGames_Demo_S2-1200x1600-35531ec1fa868e3876fac76471a24017.jpg"
+            }
+        ],
+        "seller": { "id": "o-ty5rvlnsbgdnfffytsywat86gcedkm", "name": "Broken Arms Games srls" },
+        "productSlug": "hundred-days-winemaking-simulator",
+        "urlSlug": "hundred-days-winemaking-simulator",
+        "url": null,
+        "items": [{ "id": "03cacb8754f243bfbc536c9dda0eb32e", "namespace": "4d8b727a49144090b103f6b6ba471e71" }],
+        "customAttributes": [
+            { "key": "com.epicgames.app.blacklist", "value": "[]" },
+            { "key": "developerName", "value": "Broken Arms Games" },
+            { "key": "com.epicgames.app.productSlug", "value": "hundred-days-winemaking-simulator" }
+        ],
+        "categories": [
+            { "path": "freegames" },
+            { "path": "games" },
+            { "path": "games/edition" },
+            { "path": "games/edition/base" },
+            { "path": "applications" }
+        ],
+        "tags": [
+            { "id": "1188" },
+            { "id": "21894" },
+            { "id": "21127" },
+            { "id": "21130" },
+            { "id": "19242" },
+            { "id": "16011" },
+            { "id": "9547" },
+            { "id": "15375" },
+            { "id": "1263" },
+            { "id": "1393" },
+            { "id": "21138" },
+            { "id": "16979" },
+            { "id": "21139" },
+            { "id": "21140" },
+            { "id": "17493" },
+            { "id": "21141" },
+            { "id": "18777" },
+            { "id": "1370" },
+            { "id": "18778" },
+            { "id": "21146" },
+            { "id": "1115" },
+            { "id": "21149" },
+            { "id": "10719" },
+            { "id": "21119" }
+        ],
+        "catalogNs": {
+            "mappings": [{ "pageSlug": "hundred-days-winemaking-simulator", "pageType": "productHome" }]
+        },
+        "offerMappings": [],
+        "price": {
+            "totalPrice": {
+                "discountPrice": 1999,
+                "originalPrice": 1999,
+                "voucherDiscount": 0,
+                "discount": 0,
+                "currencyCode": "EUR",
+                "currencyInfo": { "decimals": 2 },
+                "fmtPrice": { "originalPrice": "19,99 €", "discountPrice": "19,99 €", "intermediatePrice": "19,99 €" }
+            },
+            "lineOffers": [{ "appliedRules": [] }]
+        },
+        "promotions": null
+    },
+    {
+        "title": "Mocked game 16",
+        "id": "e48379072089437dbd783ef80c56fc2c",
+        "namespace": "be69d6b9214f4bc594c4cb1cd310a553",
+        "description": "Command legendary heroes to reshape a land fractured by broken oaths, reckless wars, and secret arcane powers. Claim ancient artifacts and powerful weapons to empower your cast of 30 voiced, playable characters as they form bonds and battle their way to become legends.",
+        "effectiveDate": "2021-12-17T17:00:00.000Z",
+        "offerType": "BASE_GAME",
+        "expiryDate": null,
+        "status": "ACTIVE",
+        "isCodeRedemptionOnly": false,
+        "keyImages": [
+            {
+                "type": "OfferImageWide",
+                "url": "https://cdn1.epicgames.com/spt-assets/1d1ceda7b1ba4e7893a36a1166ac3e41/dark-deity-offer-1v77p.jpg"
+            },
+            {
+                "type": "OfferImageTall",
+                "url": "https://cdn1.epicgames.com/spt-assets/1d1ceda7b1ba4e7893a36a1166ac3e41/download-dark-deity-offer-1p2y4.jpg"
+            },
+            {
+                "type": "Thumbnail",
+                "url": "https://cdn1.epicgames.com/spt-assets/1d1ceda7b1ba4e7893a36a1166ac3e41/download-dark-deity-offer-1p2y4.jpg"
+            }
+        ],
+        "seller": { "id": "o-rlswgtffm6ua68662gd37xv3lmq95q", "name": "Freedom Games" },
+        "productSlug": null,
+        "urlSlug": "1590511c2c1340ca867427feba263670",
+        "url": null,
+        "items": [{ "id": "fd6e811594ec4e588de9badba34f11a4", "namespace": "be69d6b9214f4bc594c4cb1cd310a553" }],
+        "customAttributes": [{ "key": "autoGeneratedPrice", "value": "false" }],
+        "categories": [
+            { "path": "freegames" },
+            { "path": "games/edition/base" },
+            { "path": "games/edition" },
+            { "path": "games" }
+        ],
+        "tags": [
+            { "id": "1367" },
+            { "id": "1370" },
+            { "id": "1115" },
+            { "id": "9547" },
+            { "id": "16011" },
+            { "id": "1117" },
+            { "id": "15375" }
+        ],
+        "catalogNs": { "mappings": [{ "pageSlug": "dark-deity-0b08d1", "pageType": "productHome" }] },
+        "offerMappings": [{ "pageSlug": "dark-deity-0b08d1", "pageType": "productHome" }],
+        "price": {
+            "totalPrice": {
+                "discountPrice": 2199,
+                "originalPrice": 2199,
+                "voucherDiscount": 0,
+                "discount": 0,
+                "currencyCode": "EUR",
+                "currencyInfo": { "decimals": 2 },
+                "fmtPrice": { "originalPrice": "21,99 €", "discountPrice": "21,99 €", "intermediatePrice": "21,99 €" }
+            },
+            "lineOffers": [{ "appliedRules": [] }]
+        },
+        "promotions": {
+            "promotionalOffers": [],
+            "upcomingPromotionalOffers": [
+                {
+                    "promotionalOffers": [
+                        {
+                            "startDate": "2022-11-17T16:00:00.000Z",
+                            "endDate": "2022-11-24T16:00:00.000Z",
+                            "discountSetting": { "discountType": "PERCENTAGE", "discountPercentage": 0 }
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "title": "Mocked game 17",
+        "id": "ee7f3c6725fd4fd4b8aeab8622cb770e",
+        "namespace": "4b5461ca8d1c488787b5200b420de066",
+        "description": "Prenez part au moment décisif où Lara Croft devient pilleuse de tombeaux. Dans Shadow of the Tomb Raider: Definitive Edition, vous découvrirez les derniers secrets des origines de Lara.",
+        "effectiveDate": "2021-12-30T16:00:00.000Z",
+        "offerType": "BASE_GAME",
+        "expiryDate": null,
+        "status": "ACTIVE",
+        "isCodeRedemptionOnly": false,
+        "keyImages": [
+            {
+                "type": "CodeRedemption_340x440",
+                "url": "https://cdn1.epicgames.com/offer/4b5461ca8d1c488787b5200b420de066/egs-shadowofthetombraiderdefinitiveedition-eidosmontralcrystaldynamicsnixxessoftware-s4-1200x1600-7ee40d6fa744_1200x1600-950cdb624cc75d04fe3c8c0b62ce98de"
+            },
+            {
+                "type": "OfferImageTall",
+                "url": "https://cdn1.epicgames.com/offer/4b5461ca8d1c488787b5200b420de066/egs-shadowofthetombraiderdefinitiveedition-eidosmontralcrystaldynamicsnixxessoftware-s4-1200x1600-7ee40d6fa744_1200x1600-950cdb624cc75d04fe3c8c0b62ce98de"
+            },
+            {
+                "type": "OfferImageWide",
+                "url": "https://cdn1.epicgames.com/offer/4b5461ca8d1c488787b5200b420de066/egs-shadowofthetombraiderdefinitiveedition-eidosmontralcrystaldynamicsnixxessoftware-s1-2560x1440-eca6506e95a1_2560x1440-193582a5fd76a593804e0171d6395cf4"
+            },
+            {
+                "type": "Thumbnail",
+                "url": "https://cdn1.epicgames.com/offer/4b5461ca8d1c488787b5200b420de066/egs-shadowofthetombraiderdefinitiveedition-eidosmontralcrystaldynamicsnixxessoftware-s4-1200x1600-7ee40d6fa744_1200x1600-950cdb624cc75d04fe3c8c0b62ce98de"
+            },
+            {
+                "type": "DieselStoreFrontTall",
+                "url": "https://cdn1.epicgames.com/offer/4b5461ca8d1c488787b5200b420de066/egs-shadowofthetombraiderdefinitiveedition-eidosmontralcrystaldynamicsnixxessoftware-s4-1200x1600-7ee40d6fa744_1200x1600-950cdb624cc75d04fe3c8c0b62ce98de"
+            },
+            {
+                "type": "DieselStoreFrontWide",
+                "url": "https://cdn1.epicgames.com/offer/4b5461ca8d1c488787b5200b420de066/egs-shadowofthetombraiderdefinitiveedition-eidosmontralcrystaldynamicsnixxessoftware-s1-2560x1440-eca6506e95a1_2560x1440-193582a5fd76a593804e0171d6395cf4"
+            }
+        ],
+        "seller": { "id": "o-7petn7mrlk8g86ktqm7uglcr7lfaja", "name": "Square Enix" },
+        "productSlug": "shadow-of-the-tomb-raider",
+        "urlSlug": "shadow-of-the-tomb-raider",
+        "url": null,
+        "items": [{ "id": "e7f90759e0544e42be9391d10a5c6000", "namespace": "4b5461ca8d1c488787b5200b420de066" }],
+        "customAttributes": [
+            { "key": "com.epicgames.app.blacklist", "value": "[]" },
+            { "key": "com.epicgames.app.productSlug", "value": "shadow-of-the-tomb-raider" }
+        ],
+        "categories": [
+            { "path": "freegames" },
+            { "path": "games" },
+            { "path": "games/edition" },
+            { "path": "games/edition/base" },
+            { "path": "applications" }
+        ],
+        "tags": [
+            { "id": "1216" },
+            { "id": "21122" },
+            { "id": "1188" },
+            { "id": "21894" },
+            { "id": "21127" },
+            { "id": "9547" },
+            { "id": "9549" },
+            { "id": "21138" },
+            { "id": "21139" },
+            { "id": "21140" },
+            { "id": "21109" },
+            { "id": "21141" },
+            { "id": "22485" },
+            { "id": "1370" },
+            { "id": "21146" },
+            { "id": "1117" },
+            { "id": "21149" },
+            { "id": "21119" }
+        ],
+        "catalogNs": { "mappings": [{ "pageSlug": "shadow-of-the-tomb-raider", "pageType": "productHome" }] },
+        "offerMappings": [],
+        "price": {
+            "totalPrice": {
+                "discountPrice": 3999,
+                "originalPrice": 3999,
+                "voucherDiscount": 0,
+                "discount": 0,
+                "currencyCode": "EUR",
+                "currencyInfo": { "decimals": 2 },
+                "fmtPrice": { "originalPrice": "39,99 €", "discountPrice": "39,99 €", "intermediatePrice": "39,99 €" }
+            },
+            "lineOffers": [{ "appliedRules": [] }]
+        },
+        "promotions": null
+    },
+    {
+        "title": "Mocked game 18",
+        "id": "f2496286331e405793d69807755b7b23",
+        "namespace": "25d726130e6c4fe68f88e71933bda955",
+        "description": "Dans Terraforming Mars, vous dirigez une corporation qui présente des caractéristiques particulières. Jouez des cartes Projet, renforcez la production, placez vos villes et vos espaces verts sur la carte, et disputez des récompenses et des objectifs !",
+        "effectiveDate": "2022-05-05T15:00:00.000Z",
+        "offerType": "BASE_GAME",
+        "expiryDate": null,
+        "status": "ACTIVE",
+        "isCodeRedemptionOnly": false,
+        "keyImages": [
+            {
+                "type": "OfferImageWide",
+                "url": "https://cdn1.epicgames.com/spt-assets/5199b206e46947ebad5e5c282e95776f/terraforming-mars-offer-1j70f.jpg"
+            },
+            {
+                "type": "OfferImageTall",
+                "url": "https://cdn1.epicgames.com/spt-assets/5199b206e46947ebad5e5c282e95776f/download-terraforming-mars-offer-13t2e.jpg"
+            },
+            {
+                "type": "Thumbnail",
+                "url": "https://cdn1.epicgames.com/spt-assets/5199b206e46947ebad5e5c282e95776f/download-terraforming-mars-offer-13t2e.jpg"
+            }
+        ],
+        "seller": { "id": "o-4x4bpaww55p5g3f6xpyqe2cneqxd5d", "name": "Asmodee" },
+        "productSlug": null,
+        "urlSlug": "24cdfcde68bf4a7e8b8618ac2c0c460b",
+        "url": null,
+        "items": [{ "id": "ee49486d7346465dba1f1dec85725aee", "namespace": "25d726130e6c4fe68f88e71933bda955" }],
+        "customAttributes": [
+            { "key": "autoGeneratedPrice", "value": "false" },
+            { "key": "isManuallySetPCReleaseDate", "value": "true" }
+        ],
+        "categories": [
+            { "path": "freegames" },
+            { "path": "games/edition/base" },
+            { "path": "games/edition" },
+            { "path": "games" }
+        ],
+        "tags": [
+            { "id": "1188" },
+            { "id": "21125" },
+            { "id": "1386" },
+            { "id": "9547" },
+            { "id": "21138" },
+            { "id": "1203" },
+            { "id": "1299" },
+            { "id": "21139" },
+            { "id": "21140" },
+            { "id": "21141" },
+            { "id": "1370" },
+            { "id": "1115" },
+            { "id": "21149" },
+            { "id": "10719" }
+        ],
+        "catalogNs": { "mappings": [{ "pageSlug": "terraforming-mars-18c3ad", "pageType": "productHome" }] },
+        "offerMappings": [{ "pageSlug": "terraforming-mars-18c3ad", "pageType": "productHome" }],
+        "price": {
+            "totalPrice": {
+                "discountPrice": 1999,
+                "originalPrice": 1999,
+                "voucherDiscount": 0,
+                "discount": 0,
+                "currencyCode": "EUR",
+                "currencyInfo": { "decimals": 2 },
+                "fmtPrice": { "originalPrice": "19,99 €", "discountPrice": "19,99 €", "intermediatePrice": "19,99 €" }
+            },
+            "lineOffers": [{ "appliedRules": [] }]
+        },
+        "promotions": null
+    },
+    {
+        "title": "Mocked game 19",
+        "id": "e8e34d364a4c469e924867013fc1816f",
+        "namespace": "95e09a8c24c44684bca1a6f25aea920c",
+        "description": "Incarnez Ash Williams ou l'un de ses amis de la franchise emblématique Evil Dead et travaillez de concert dans un jeu plein de séquences d'action multijoueur en coop et JcJ !",
+        "effectiveDate": "2022-05-13T07:00:00.000Z",
+        "offerType": "BASE_GAME",
+        "expiryDate": null,
+        "status": "ACTIVE",
+        "isCodeRedemptionOnly": false,
+        "keyImages": [
+            {
+                "type": "OfferImageTall",
+                "url": "https://cdn1.epicgames.com/offer/95e09a8c24c44684bca1a6f25aea920c/EGS_EvilDeadTheGame_SaberInteractiveInc_S2_1200x1600-8e839d708bc638cd58c219ae38d58f6f_1200x1600-8e839d708bc638cd58c219ae38d58f6f"
+            },
+            {
+                "type": "OfferImageWide",
+                "url": "https://cdn1.epicgames.com/offer/95e09a8c24c44684bca1a6f25aea920c/EGS_EvilDeadTheGame_SaberInteractiveInc_S1_2560x1440-fde136bc32f2b93006b9df0bc421fec0_2560x1440-fde136bc32f2b93006b9df0bc421fec0"
+            }
+        ],
+        "seller": { "id": "o-2xlz78ngz5ubvus9sff9blglee43uk", "name": "Saber Interactive" },
+        "productSlug": "evil-dead-the-game",
+        "urlSlug": "evil-dead-the-game",
+        "url": null,
+        "items": [{ "id": "19b2d58e393c45389f0589c333450269", "namespace": "95e09a8c24c44684bca1a6f25aea920c" }],
+        "customAttributes": [{ "key": "com.epicgames.app.productSlug", "value": "evil-dead-the-game" }],
+        "categories": [
+            { "path": "freegames" },
+            { "path": "games" },
+            { "path": "games/edition" },
+            { "path": "games/edition/base" },
+            { "path": "applications" }
+        ],
+        "tags": [
+            { "id": "1216" },
+            { "id": "21122" },
+            { "id": "21125" },
+            { "id": "9547" },
+            { "id": "1264" },
+            { "id": "21138" },
+            { "id": "1203" },
+            { "id": "1299" },
+            { "id": "21139" },
+            { "id": "21140" },
+            { "id": "21109" },
+            { "id": "21141" },
+            { "id": "22485" },
+            { "id": "21149" }
+        ],
+        "catalogNs": { "mappings": [{ "pageSlug": "evil-dead-the-game", "pageType": "productHome" }] },
+        "offerMappings": [],
+        "price": {
+            "totalPrice": {
+                "discountPrice": 3999,
+                "originalPrice": 3999,
+                "voucherDiscount": 0,
+                "discount": 0,
+                "currencyCode": "EUR",
+                "currencyInfo": { "decimals": 2 },
+                "fmtPrice": { "originalPrice": "39,99 €", "discountPrice": "39,99 €", "intermediatePrice": "39,99 €" }
+            },
+            "lineOffers": [{ "appliedRules": [] }]
+        },
+        "promotions": {
+            "promotionalOffers": [],
+            "upcomingPromotionalOffers": [
+                {
+                    "promotionalOffers": [
+                        {
+                            "startDate": "2022-11-17T16:00:00.000Z",
+                            "endDate": "2022-11-24T16:00:00.000Z",
+                            "discountSetting": { "discountType": "PERCENTAGE", "discountPercentage": 0 }
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    {
+        "title": "Mocked game 20",
+        "id": "5eb27cf1747c40b5a0d4f5492774678d",
+        "namespace": "226306adde104c9092247dcd4bfa1499",
+        "description": "Build and expand your repair service empire in this incredibly detailed and highly realistic simulation game, where attention to car detail is astonishing. Find classic, unique cars in the new Barn Find module and Junkyard module.",
+        "effectiveDate": "2022-06-23T15:00:00.000Z",
+        "offerType": "BASE_GAME",
+        "expiryDate": null,
+        "status": "ACTIVE",
+        "isCodeRedemptionOnly": false,
+        "keyImages": [
+            {
+                "type": "OfferImageTall",
+                "url": "https://cdn1.epicgames.com/offer/226306adde104c9092247dcd4bfa1499/EGS_CarMechanicSimulator2018_RedDotGames_S2_1200x1600-f285924f9144353f57ac4631f0c689e6"
+            },
+            {
+                "type": "OfferImageWide",
+                "url": "https://cdn1.epicgames.com/offer/226306adde104c9092247dcd4bfa1499/EGS_CarMechanicSimulator2018_RedDotGames_S1_2560x1440-3489ef1499e64c168fdf4b14926d2c23"
+            },
+            {
+                "type": "Thumbnail",
+                "url": "https://cdn1.epicgames.com/offer/226306adde104c9092247dcd4bfa1499/EGS_CarMechanicSimulator2018_RedDotGames_S2_1200x1600-f285924f9144353f57ac4631f0c689e6"
+            }
+        ],
+        "seller": { "id": "o-5n5cbrasl5yzexjc529rypg8eh8lfb", "name": "PlayWay" },
+        "productSlug": "car-mechanic-simulator-2018",
+        "urlSlug": "car-mechanic-simulator-2018",
+        "url": null,
+        "items": [{ "id": "49a3a8597c4240ecaf1f9068106c9869", "namespace": "226306adde104c9092247dcd4bfa1499" }],
+        "customAttributes": [
+            { "key": "com.epicgames.app.blacklist", "value": "[]" },
+            { "key": "com.epicgames.app.productSlug", "value": "car-mechanic-simulator-2018" }
+        ],
+        "categories": [
+            { "path": "freegames" },
+            { "path": "games" },
+            { "path": "games/edition" },
+            { "path": "games/edition/base" },
+            { "path": "applications" }
+        ],
+        "tags": [
+            { "id": "21120" },
+            { "id": "1188" },
+            { "id": "21127" },
+            { "id": "9547" },
+            { "id": "1393" },
+            { "id": "21138" },
+            { "id": "21139" },
+            { "id": "21140" },
+            { "id": "21141" },
+            { "id": "1370" },
+            { "id": "21146" },
+            { "id": "21149" },
+            { "id": "21119" }
+        ],
+        "catalogNs": { "mappings": [{ "pageSlug": "car-mechanic-simulator-2018", "pageType": "productHome" }] },
+        "offerMappings": [],
+        "price": {
+            "totalPrice": {
+                "discountPrice": 1599,
+                "originalPrice": 1599,
+                "voucherDiscount": 0,
+                "discount": 0,
+                "currencyCode": "EUR",
+                "currencyInfo": { "decimals": 2 },
+                "fmtPrice": { "originalPrice": "15,99 €", "discountPrice": "15,99 €", "intermediatePrice": "15,99 €" }
+            },
+            "lineOffers": [{ "appliedRules": [] }]
+        },
+        "promotions": null
+    },
+    {
+        "title": "Mocked game 21",
+        "id": "a125d72a47a1490aba78c4e79a40395d",
+        "namespace": "1b737464d3c441f8956315433be02d3b",
+        "description": "A Game of Thrones: The Board Game est l'adaptation numérique du jeu de plateau stratégique à succès créé par Fantasy Flight Games.",
+        "effectiveDate": "2022-06-23T15:00:00.000Z",
+        "offerType": "BASE_GAME",
+        "expiryDate": null,
+        "status": "ACTIVE",
+        "isCodeRedemptionOnly": false,
+        "keyImages": [
+            {
+                "type": "OfferImageWide",
+                "url": "https://cdn1.epicgames.com/spt-assets/61c1413e3db0423f9ddd4a5edbee717e/a-game-of-thrones-offer-11gxu.jpg"
+            },
+            {
+                "type": "OfferImageTall",
+                "url": "https://cdn1.epicgames.com/spt-assets/61c1413e3db0423f9ddd4a5edbee717e/download-a-game-of-thrones-offer-1q8ei.jpg"
+            },
+            {
+                "type": "Thumbnail",
+                "url": "https://cdn1.epicgames.com/spt-assets/61c1413e3db0423f9ddd4a5edbee717e/download-a-game-of-thrones-offer-1q8ei.jpg"
+            }
+        ],
+        "seller": { "id": "o-4x4bpaww55p5g3f6xpyqe2cneqxd5d", "name": "Asmodee" },
+        "productSlug": null,
+        "urlSlug": "ce6f7ab4edab4cc2aa7e0ff4c19540e2",
+        "url": null,
+        "items": [{ "id": "dc6ae31efba7401fa72ed93f0bd37c6a", "namespace": "1b737464d3c441f8956315433be02d3b" }],
+        "customAttributes": [
+            { "key": "autoGeneratedPrice", "value": "false" },
+            { "key": "isManuallySetPCReleaseDate", "value": "true" }
+        ],
+        "categories": [
+            { "path": "freegames" },
+            { "path": "games/edition/base" },
+            { "path": "games/edition" },
+            { "path": "games" }
+        ],
+        "tags": [
+            { "id": "21138" },
+            { "id": "1203" },
+            { "id": "1299" },
+            { "id": "21139" },
+            { "id": "1188" },
+            { "id": "21140" },
+            { "id": "21125" },
+            { "id": "21141" },
+            { "id": "1370" },
+            { "id": "1115" },
+            { "id": "9547" },
+            { "id": "21149" }
+        ],
+        "catalogNs": { "mappings": [{ "pageSlug": "a-game-of-thrones-5858a3", "pageType": "productHome" }] },
+        "offerMappings": [{ "pageSlug": "a-game-of-thrones-5858a3", "pageType": "productHome" }],
+        "price": {
+            "totalPrice": {
+                "discountPrice": 1999,
+                "originalPrice": 1999,
+                "voucherDiscount": 0,
+                "discount": 0,
+                "currencyCode": "EUR",
+                "currencyInfo": { "decimals": 2 },
+                "fmtPrice": { "originalPrice": "19,99 €", "discountPrice": "19,99 €", "intermediatePrice": "19,99 €" }
+            },
+            "lineOffers": [{ "appliedRules": [] }]
+        },
+        "promotions": null
+    },
+    {
+        "title": "Mocked game 22",
+        "id": "d6f01b1827c64ed388191ae507fe7c1b",
+        "namespace": "fa702d34a37248ba98fb17f680c085e3",
+        "description": "Préparez-vous pour l'avenir™\nDécouvrez le jeu le plus acclamé de 2008 comme jamais vous ne l'avez vu avec Fallout 3 : Game of the Year Edition. Créez votre personnage et entrez dans un monde post-apocalyptique où la survie est une lutte de tous les instants.",
+        "effectiveDate": "2022-10-20T15:00:00.000Z",
+        "offerType": "BASE_GAME",
+        "expiryDate": null,
+        "status": "ACTIVE",
+        "isCodeRedemptionOnly": false,
+        "keyImages": [
+            {
+                "type": "OfferImageTall",
+                "url": "https://cdn1.epicgames.com/offer/fa702d34a37248ba98fb17f680c085e3/EGS_Fallout3GameoftheYearEdition_BethesdaGameStudios_S2_1200x1600-e2ba392652a1f57c4feb65d6bbd1f963"
+            },
+            {
+                "type": "OfferImageWide",
+                "url": "https://cdn1.epicgames.com/offer/fa702d34a37248ba98fb17f680c085e3/EGS_Fallout3GameoftheYearEdition_BethesdaGameStudios_S1_2560x1440-073f5b4cf358f437a052a3c29806efa0"
+            },
+            {
+                "type": "ProductLogo",
+                "url": "https://cdn1.epicgames.com/offer/fa702d34a37248ba98fb17f680c085e3/EGS_Fallout3GameoftheYearEdition_BethesdaGameStudios_IC1_400x400-5e37dfe1d35c9ccf25c8889fe7218613"
+            },
+            {
+                "type": "Thumbnail",
+                "url": "https://cdn1.epicgames.com/offer/fa702d34a37248ba98fb17f680c085e3/EGS_Fallout3GameoftheYearEdition_BethesdaGameStudios_S2_1200x1600-e2ba392652a1f57c4feb65d6bbd1f963"
+            }
+        ],
+        "seller": { "id": "o-bthbhn6wd7fzj73v5p4436ucn3k37u", "name": "Bethesda Softworks LLC" },
+        "productSlug": "fallout-3-game-of-the-year-edition",
+        "urlSlug": "fallout-3-game-of-the-year-edition",
+        "url": null,
+        "items": [{ "id": "6b750e631e414927bde5b3e13b647443", "namespace": "fa702d34a37248ba98fb17f680c085e3" }],
+        "customAttributes": [
+            { "key": "com.epicgames.app.blacklist", "value": "[]" },
+            { "key": "com.epicgames.app.productSlug", "value": "fallout-3-game-of-the-year-edition" }
+        ],
+        "categories": [
+            { "path": "freegames" },
+            { "path": "games" },
+            { "path": "games/edition" },
+            { "path": "games/edition/base" },
+            { "path": "applications" }
+        ],
+        "tags": [
+            { "id": "21122" },
+            { "id": "1188" },
+            { "id": "21894" },
+            { "id": "21127" },
+            { "id": "9547" },
+            { "id": "21137" },
+            { "id": "21138" },
+            { "id": "21139" },
+            { "id": "21140" },
+            { "id": "21141" },
+            { "id": "1367" },
+            { "id": "1370" },
+            { "id": "1307" },
+            { "id": "21147" },
+            { "id": "1117" },
+            { "id": "21149" },
+            { "id": "21119" }
+        ],
+        "catalogNs": {
+            "mappings": [{ "pageSlug": "fallout-3-game-of-the-year-edition", "pageType": "productHome" }]
+        },
+        "offerMappings": [],
+        "price": {
+            "totalPrice": {
+                "discountPrice": 1999,
+                "originalPrice": 1999,
+                "voucherDiscount": 0,
+                "discount": 0,
+                "currencyCode": "EUR",
+                "currencyInfo": { "decimals": 2 },
+                "fmtPrice": { "originalPrice": "19,99 €", "discountPrice": "19,99 €", "intermediatePrice": "19,99 €" }
+            },
+            "lineOffers": [{ "appliedRules": [] }]
+        },
+        "promotions": null
+    },
+    {
+        "title": "Mocked game 23",
+        "id": "e068e168886a4a90a4e36a310e3bda32",
+        "namespace": "3f7bd21610f743e598fa8e955500f5b7",
+        "description": "Evoland Legendary Edition rassemble deux jeux de rôle uniques, avec un style graphique et un gameplay qui évoluent au fur et à mesure du jeu !",
+        "effectiveDate": "2022-10-20T15:00:00.000Z",
+        "offerType": "BASE_GAME",
+        "expiryDate": null,
+        "status": "ACTIVE",
+        "isCodeRedemptionOnly": false,
+        "keyImages": [
+            {
+                "type": "OfferImageWide",
+                "url": "https://cdn1.epicgames.com/spt-assets/aafde465b31e4bd5a169ff1c8a164a17/evoland-legendary-edition-1y7m0.png"
+            },
+            {
+                "type": "OfferImageTall",
+                "url": "https://cdn1.epicgames.com/spt-assets/aafde465b31e4bd5a169ff1c8a164a17/evoland-legendary-edition-1j93v.png"
+            },
+            {
+                "type": "Thumbnail",
+                "url": "https://cdn1.epicgames.com/spt-assets/aafde465b31e4bd5a169ff1c8a164a17/evoland-legendary-edition-1j93v.png"
+            }
+        ],
+        "seller": { "id": "o-ealhln64lfep9ww929uq9qcdmbyfn4", "name": "Shiro Games SAS" },
+        "productSlug": null,
+        "urlSlug": "224c60bb93864e1c8a1900bcf7d661dd",
+        "url": null,
+        "items": [{ "id": "c829f27d0ab0406db8edf2b97562ee93", "namespace": "3f7bd21610f743e598fa8e955500f5b7" }],
+        "customAttributes": [
+            { "key": "autoGeneratedPrice", "value": "false" },
+            { "key": "isManuallySetPCReleaseDate", "value": "true" }
+        ],
+        "categories": [
+            { "path": "freegames" },
+            { "path": "games/edition" },
+            { "path": "games" },
+            { "path": "games/edition/base" }
+        ],
+        "tags": [
+            { "id": "1216" },
+            { "id": "21109" },
+            { "id": "1367" },
+            { "id": "1370" },
+            { "id": "9547" },
+            { "id": "1117" },
+            { "id": "9549" }
+        ],
+        "catalogNs": {
+            "mappings": [{ "pageSlug": "evoland-legendary-edition-5753ec", "pageType": "productHome" }]
+        },
+        "offerMappings": [{ "pageSlug": "evoland-legendary-edition-5753ec", "pageType": "productHome" }],
+        "price": {
+            "totalPrice": {
+                "discountPrice": 1999,
+                "originalPrice": 1999,
+                "voucherDiscount": 0,
+                "discount": 0,
+                "currencyCode": "EUR",
+                "currencyInfo": { "decimals": 2 },
+                "fmtPrice": { "originalPrice": "19,99 €", "discountPrice": "19,99 €", "intermediatePrice": "19,99 €" }
+            },
+            "lineOffers": [{ "appliedRules": [] }]
+        },
+        "promotions": null
+    },
+    {
+        "title": "Mocked game 24",
+        "id": "44a89fd06011419d9df5fe412ab305e1",
+        "namespace": "caf357c955344eaeaaaddb3c8357dbdf",
+        "description": "Même la plus modeste des personnes peut faire la différence. Rejoignez Alba dans son combat pour sauvegarder la faune de sa belle île. Une révolution pourrait bien être en marche.",
+        "effectiveDate": "2022-11-10T16:00:00.000Z",
+        "offerType": "BASE_GAME",
+        "expiryDate": null,
+        "status": "ACTIVE",
+        "isCodeRedemptionOnly": false,
+        "keyImages": [
+            {
+                "type": "OfferImageWide",
+                "url": "https://cdn1.epicgames.com/spt-assets/c816cec291404812a9eacc03387dcbca/alba--a-wildlife-adventure-offer-16frq.jpg"
+            },
+            {
+                "type": "OfferImageTall",
+                "url": "https://cdn1.epicgames.com/spt-assets/c816cec291404812a9eacc03387dcbca/download-alba--a-wildlife-adventure-offer-zbvu8.jpg"
+            },
+            {
+                "type": "Thumbnail",
+                "url": "https://cdn1.epicgames.com/spt-assets/c816cec291404812a9eacc03387dcbca/download-alba--a-wildlife-adventure-offer-zbvu8.jpg"
+            }
+        ],
+        "seller": { "id": "o-yw5ga5z854qs64ld82qey3dz2d7z32", "name": "Plug In Digital SAS" },
+        "productSlug": null,
+        "urlSlug": "35ab996574a049cba880170e8071c410",
+        "url": null,
+        "items": [{ "id": "930f9eb5582b4395b8c0c7a0b3ce093d", "namespace": "caf357c955344eaeaaaddb3c8357dbdf" }],
+        "customAttributes": [
+            { "key": "autoGeneratedPrice", "value": "false" },
+            { "key": "isManuallySetPCReleaseDate", "value": "true" }
+        ],
+        "categories": [
+            { "path": "freegames" },
+            { "path": "games/edition" },
+            { "path": "games" },
+            { "path": "games/edition/base" }
+        ],
+        "tags": [{ "id": "1296" }, { "id": "1370" }, { "id": "9547" }],
+        "catalogNs": {
+            "mappings": [{ "pageSlug": "alba-a-wildlife-adventure-93736a", "pageType": "productHome" }]
+        },
+        "offerMappings": [{ "pageSlug": "alba-a-wildlife-adventure-93736a", "pageType": "productHome" }],
+        "price": {
+            "totalPrice": {
+                "discountPrice": 0,
+                "originalPrice": 1699,
+                "voucherDiscount": 0,
+                "discount": 1699,
+                "currencyCode": "EUR",
+                "currencyInfo": { "decimals": 2 },
+                "fmtPrice": { "originalPrice": "16,99 €", "discountPrice": "0", "intermediatePrice": "0" }
+            },
+            "lineOffers": [
+                {
+                    "appliedRules": [
+                        {
+                            "id": "15ca8fb5e8014caab93164bea2071f00",
+                            "endDate": "2022-11-17T16:00:00.000Z",
+                            "discountSetting": { "discountType": "PERCENTAGE" }
+                        }
+                    ]
+                }
+            ]
+        },
+        "promotions": {
+            "promotionalOffers": [
+                {
+                    "promotionalOffers": [
+                        {
+                            "startDate": "2022-11-10T16:00:00.000Z",
+                            "endDate": "2022-11-17T16:00:00.000Z",
+                            "discountSetting": { "discountType": "PERCENTAGE", "discountPercentage": 0 }
+                        }
+                    ]
+                }
+            ],
+            "upcomingPromotionalOffers": []
+        }
+    },
+    {
+        "title": "Mocked game 25",
+        "id": "a22a7af179c54b86a93f3193ace8f7f4",
+        "namespace": "d5241c76f178492ea1540fce45616757",
+        "description": "Maneater",
+        "effectiveDate": "2099-01-01T00:00:00.000Z",
+        "offerType": "OTHERS",
+        "expiryDate": null,
+        "status": "ACTIVE",
+        "isCodeRedemptionOnly": true,
+        "keyImages": [
+            {
+                "type": "VaultClosed",
+                "url": "https://cdn1.epicgames.com/offer/d5241c76f178492ea1540fce45616757/egs-vault-tease-generic-promo-1920x1080_1920x1080-f7742c265e217510835ed14e04c48b4b"
+            },
+            {
+                "type": "DieselStoreFrontTall",
+                "url": "https://cdn1.epicgames.com/offer/d5241c76f178492ea1540fce45616757/egs-vault-tease-generic-promo-1920x1080_1920x1080-f7742c265e217510835ed14e04c48b4b"
+            },
+            {
+                "type": "OfferImageTall",
+                "url": "https://cdn1.epicgames.com/offer/d5241c76f178492ea1540fce45616757/egs-vault-carousel-mobile-thumbnail-1200x1600_1200x1600-1f45bf1ceb21c1ca2947f6df5ece5346"
+            },
+            {
+                "type": "VaultOpened",
+                "url": "https://cdn1.epicgames.com/offer/d5241c76f178492ea1540fce45616757/egs-vault-w4-1920x1080_1920x1080-2df36fe63c18ff6fcb5febf3dd7ed06e"
+            },
+            {
+                "type": "DieselStoreFrontWide",
+                "url": "https://cdn1.epicgames.com/offer/d5241c76f178492ea1540fce45616757/egs-vault-w4-1920x1080_1920x1080-2df36fe63c18ff6fcb5febf3dd7ed06e"
+            },
+            {
+                "type": "OfferImageWide",
+                "url": "https://cdn1.epicgames.com/offer/d5241c76f178492ea1540fce45616757/egs-vault-w4-1920x1080_1920x1080-2df36fe63c18ff6fcb5febf3dd7ed06e"
+            }
+        ],
+        "seller": { "id": "o-ufmrk5furrrxgsp5tdngefzt5rxdcn", "name": "Epic Dev Test Account" },
+        "productSlug": "maneater",
+        "urlSlug": "game-4",
+        "url": null,
+        "items": [{ "id": "8341d7c7e4534db7848cc428aa4cbe5a", "namespace": "d5241c76f178492ea1540fce45616757" }],
+        "customAttributes": [
+            { "key": "com.epicgames.app.freegames.vault.close", "value": "[]" },
+            { "key": "com.epicgames.app.freegames.vault.slug", "value": "free-games" },
+            { "key": "com.epicgames.app.freegames.vault.open", "value": "[]" },
+            { "key": "com.epicgames.app.productSlug", "value": "maneater" }
+        ],
+        "categories": [
+            { "path": "freegames/vaulted" },
+            { "path": "freegames" },
+            { "path": "games" },
+            { "path": "applications" }
+        ],
+        "tags": [],
+        "catalogNs": { "mappings": [] },
+        "offerMappings": [],
+        "price": {
+            "totalPrice": {
+                "discountPrice": 0,
+                "originalPrice": 0,
+                "voucherDiscount": 0,
+                "discount": 0,
+                "currencyCode": "EUR",
+                "currencyInfo": { "decimals": 2 },
+                "fmtPrice": { "originalPrice": "0", "discountPrice": "0", "intermediatePrice": "0" }
+            },
+            "lineOffers": [{ "appliedRules": [] }]
+        },
+        "promotions": null
+    },
+    {
+        "title": "Mocked game 26",
+        "id": "1d41b93230e54bdd80c559d72adb7f4f",
+        "namespace": "d5241c76f178492ea1540fce45616757",
+        "description": "Wolfenstein: The New Order",
+        "effectiveDate": "2099-01-01T00:00:00.000Z",
+        "offerType": "OTHERS",
+        "expiryDate": null,
+        "status": "ACTIVE",
+        "isCodeRedemptionOnly": true,
+        "keyImages": [
+            {
+                "type": "VaultClosed",
+                "url": "https://cdn1.epicgames.com/offer/d5241c76f178492ea1540fce45616757/egs-vault-tease-generic-promo-1920x1080_1920x1080-f7742c265e217510835ed14e04c48b4b"
+            },
+            {
+                "type": "OfferImageTall",
+                "url": "https://cdn1.epicgames.com/offer/d5241c76f178492ea1540fce45616757/egs-vault-carousel-mobile-thumbnail-1200x1600_1200x1600-1f45bf1ceb21c1ca2947f6df5ece5346"
+            },
+            {
+                "type": "OfferImageWide",
+                "url": "https://cdn1.epicgames.com/offer/d5241c76f178492ea1540fce45616757/egs-vault-w3-1920x1080_1920x1080-4a501d33fb4ac641e3e1e290dcc0e6c1"
+            },
+            {
+                "type": "DieselStoreFrontWide",
+                "url": "https://cdn1.epicgames.com/offer/d5241c76f178492ea1540fce45616757/egs-vault-w3-1920x1080_1920x1080-4a501d33fb4ac641e3e1e290dcc0e6c1"
+            },
+            {
+                "type": "VaultOpened",
+                "url": "https://cdn1.epicgames.com/offer/d5241c76f178492ea1540fce45616757/egs-vault-w3-1920x1080_1920x1080-4a501d33fb4ac641e3e1e290dcc0e6c1"
+            }
+        ],
+        "seller": { "id": "o-ufmrk5furrrxgsp5tdngefzt5rxdcn", "name": "Epic Dev Test Account" },
+        "productSlug": "wolfenstein-the-new-order",
+        "urlSlug": "game-3",
+        "url": null,
+        "items": [{ "id": "8341d7c7e4534db7848cc428aa4cbe5a", "namespace": "d5241c76f178492ea1540fce45616757" }],
+        "customAttributes": [
+            { "key": "com.epicgames.app.freegames.vault.close", "value": "[]" },
+            { "key": "com.epicgames.app.freegames.vault.slug", "value": "free-games" },
+            { "key": "com.epicgames.app.freegames.vault.open", "value": "[]" },
+            { "key": "com.epicgames.app.productSlug", "value": "wolfenstein-the-new-order" }
+        ],
+        "categories": [
+            { "path": "freegames/vaulted" },
+            { "path": "freegames" },
+            { "path": "games" },
+            { "path": "applications" }
+        ],
+        "tags": [],
+        "catalogNs": { "mappings": [] },
+        "offerMappings": [],
+        "price": {
+            "totalPrice": {
+                "discountPrice": 0,
+                "originalPrice": 0,
+                "voucherDiscount": 0,
+                "discount": 0,
+                "currencyCode": "EUR",
+                "currencyInfo": { "decimals": 2 },
+                "fmtPrice": { "originalPrice": "0", "discountPrice": "0", "intermediatePrice": "0" }
+            },
+            "lineOffers": [{ "appliedRules": [] }]
+        },
+        "promotions": null
     }
 ]

--- a/test/helpers/epic.games.mapper.test.ts
+++ b/test/helpers/epic.games.mapper.test.ts
@@ -1,6 +1,6 @@
 import { logger } from "../../src/config/logger.config";
 import { EpicGamesMapper } from "../../src/helpers/epic.games.mapper";
-import { GameCacheDocumentInterface } from "../../src/interfaces/cache.interface";
+import { GameInterface } from "../../src/interfaces/game.interface";
 import { Element } from "../../src/interfaces/client.interface";
 import gamesJSON from "../data/games.json";
 
@@ -11,7 +11,7 @@ beforeAll(() => {
     logger.silent = true;
 });
 
-describe("Test Epic Games mapper", () => {
+describe("EpicGamesMapper", () => {
     /**
      * Deep clone the games.json data.
      */
@@ -56,20 +56,20 @@ describe("Test Epic Games mapper", () => {
         expect(games).toHaveLength(0);
 
         // when
-        const gameCacheDocuments: GameCacheDocumentInterface[] = EpicGamesMapper.map(games);
+        const mappedGames: GameInterface[] = EpicGamesMapper.map(games);
 
         // then
-        expect(gameCacheDocuments).toBeInstanceOf(Array);
-        expect(gameCacheDocuments).toHaveLength(0);
+        expect(mappedGames).toBeInstanceOf(Array);
+        expect(mappedGames).toHaveLength(0);
     });
 
-    test("given 12 elements to map, when map elements, then retrieve 12 game cache documents", () => {
+    test("given 26 elements to map, when map elements, then retrieve 26 games cache documents", () => {
         // given
 
         // when
-        const gameCacheDocuments: GameCacheDocumentInterface[] = EpicGamesMapper.map(games);
+        const mappedGames: GameInterface[] = EpicGamesMapper.map(games);
 
         // then
-        expect(gameCacheDocuments).toHaveLength(12);
+        expect(mappedGames).toHaveLength(26);
     });
 });


### PR DESCRIPTION
### Problem

- The email contains a game with a price

### Diagnostic

- If the game has a current promotion (not particularly free) and if it will be free next week, the mapper takes the first date

### Solution

- Add a new field in interface `Element` : `free` which is a boolean.
- The filter method in the `game.service` which check the discount will set the boolean to true or false
- With this field the mapper will be able to choose the right date for the promotion