### PR TITLE
👷 Disable build and push image job if is dependabot

### DIFF
--- a/.github/workflows/onPushMainPrMain.yaml
+++ b/.github/workflows/onPushMainPrMain.yaml
@@ -135,6 +135,8 @@ jobs:
 
         needs: release
 
+        if: ${{ github.actor != 'dependabot[bot]' }} # skip this job if the actor is dependabot
+
         steps:
             - name: 📥 Checkout repository
               uses: actions/checkout@v3


### PR DESCRIPTION
to avoid create and deploy multiple image